### PR TITLE
Add esp32 interface

### DIFF
--- a/examples/cybergear_m5_bridge/cybergear_m5_bridge.ino
+++ b/examples/cybergear_m5_bridge/cybergear_m5_bridge.ino
@@ -1,21 +1,14 @@
 #include <Arduino.h>
 #include <math.h>
-#include <mcp_can.h>
 #include <M5Stack.h>
 #include "ros2_logo.hh"
 #include "cybergear_bridge.hh"
 #include "cybergear_controller.hh"
-
-
-/**
- * @brief Init can interface
- */
-void init_can();
-void can_receive_task();
-
-// init MCP_CAN object
-#define CAN0_INT 15  // Set INT to pin 2
-MCP_CAN CAN0(12);    // Set CS to pin 10
+#ifdef USE_ESP32_CAN
+#include "cybergear_can_interface_esp32.hh"
+#else
+#include "cybergear_can_interface_mcp.hh"
+#endif
 
 // setup master can id and motor can id (default cybergear can id is 0x7F)
 uint8_t MASTER_CAN_ID = 0x00;
@@ -26,11 +19,16 @@ std::vector<uint8_t> motor_ids = {MOT_LEADER_CAN_ID, MOT_FOLLOWER_CAN_ID};
 // init cybergeardriver
 CybergearController controller = CybergearController(MASTER_CAN_ID);
 CybergearBridge bridge = CybergearBridge(&controller, &Serial);
+#ifdef USE_ESP32_CAN
+CybergearCanInterfaceEsp32 interface;
+#else
+CybergearCanInterfaceMcp interface;
+#endif
 
 
 void setup()
 {
-  M5.begin(true,true,false);
+  M5.begin(true, true, false);
   Serial.begin(2000000);
   Serial.flush();
 
@@ -38,8 +36,8 @@ void setup()
   M5.Lcd.drawBitmap((M5.Lcd.width() - imgWidth)/2, (M5.Lcd.height() - imgHeight)/2, imgWidth, imgHeight, (uint16_t *)img);
 
   // init cybergear driver
-  init_can();
-  controller.init(motor_ids, MODE_CURRENT, &CAN0);
+  interface.init();
+  controller.init(motor_ids, MODE_CURRENT, &interface);
 
   delay(1000);
   M5.Lcd.fillScreen(BLACK);
@@ -51,11 +49,4 @@ void loop()
   M5.update();
   bridge.process_request_command();
   bridge.process_motor_response();
-}
-
-void init_can()
-{
-  CAN0.begin(MCP_ANY, CAN_1000KBPS, MCP_8MHZ);
-  CAN0.setMode(MCP_NORMAL);  // Set operation mode to normal so the MCP2515 sends acks to received data.
-  pinMode(CAN0_INT, INPUT);  // Configuring pin for /INT input
 }

--- a/platformio.ini
+++ b/platformio.ini
@@ -16,3 +16,5 @@ lib_deps =
   m5stack/M5Stack@^0.4.6
   coryjfowler/mcp_can@^1.5.0
   Locoduino/RingBuffer@^1.0.4
+  https://github.com/project-sternbergia/arduino-CAN
+

--- a/src/cybergear_bridge.cpp
+++ b/src/cybergear_bridge.cpp
@@ -61,7 +61,7 @@ void CybergearBridge::process_request_command()
 
 void CybergearBridge::process_motor_response()
 {
-  p_controller_->process_can_packet();
+  p_controller_->process_packet();
   std::vector<uint8_t> ids = p_controller_->motor_ids();
   for (uint8_t idx = 0; idx < ids.size(); ++idx) {
     if (p_controller_->check_update_flag(ids[idx])) {
@@ -76,7 +76,7 @@ void CybergearBridge::process_enable_motor_request(const ByteArray& request_pack
   EnableRequestPacket request(request_packet);
   if (request.unpack()) {
     p_controller_->enable_motor(request.id(), request.control_mode());
-    p_controller_->process_can_packet();
+    p_controller_->process_packet();
   }
 }
 
@@ -85,7 +85,7 @@ void CybergearBridge::process_reset_motor_request(const ByteArray& request_packe
   ResetRequestPacket request(request_packet);
   if (request.unpack()) {
     p_controller_->reset_motor(request.id());
-    p_controller_->process_can_packet();
+    p_controller_->process_packet();
   }
 }
 
@@ -94,7 +94,7 @@ void CybergearBridge::process_position_control_request(const ByteArray& request_
   ControlPositionRequestPacket request(request_packet);
   if (request.unpack()) {
     p_controller_->send_position_command(request.id(), request.ref_position());
-    p_controller_->process_can_packet();
+    p_controller_->process_packet();
   }
 }
 
@@ -103,7 +103,7 @@ void CybergearBridge::process_speed_control_request(const ByteArray& request_pac
   ControlSpeedRequestPacket request(request_packet);
   if (request.unpack()) {
     p_controller_->send_speed_command(request.id(), request.ref_speed());
-    p_controller_->process_can_packet();
+    p_controller_->process_packet();
   }
 }
 
@@ -112,7 +112,7 @@ void CybergearBridge::process_current_control_request(const ByteArray& request_p
   ControlCurrentRequestPacket request(request_packet);
   if (request.unpack()) {
     p_controller_->send_current_command(request.id(), request.ref_current());
-    p_controller_->process_can_packet();
+    p_controller_->process_packet();
   }
 }
 
@@ -127,7 +127,7 @@ void CybergearBridge::process_motion_control_request(const ByteArray& request_pa
     cmd.kp = request.kp();
     cmd.kd = request.kd();
     p_controller_->send_motion_command(request.id(), cmd);
-    p_controller_->process_can_packet();
+    p_controller_->process_packet();
   }
 }
 
@@ -136,7 +136,7 @@ void CybergearBridge::process_set_mech_position_to_zero_request(const ByteArray&
   SetMechPosToZeroRequestPacket request(request_packet);
   if (request.unpack()) {
     p_controller_->set_mech_position_to_zero(request.id());
-    p_controller_->process_can_packet();
+    p_controller_->process_packet();
   }
 }
 
@@ -145,7 +145,7 @@ void CybergearBridge::process_set_limit_speed(const ByteArray& request_packet)
   SetLimitSpeedRequestPacket request(request_packet);
   if (request.unpack()) {
     p_controller_->set_speed_limit(request.id(), request.limit_speed());
-    p_controller_->process_can_packet();
+    p_controller_->process_packet();
   }
 }
 
@@ -154,7 +154,7 @@ void CybergearBridge::process_set_limit_current(const ByteArray& request_packet)
   SetLimitCurrentRequestPacket request(request_packet);
   if (request.unpack()) {
     p_controller_->set_current_limit(request.id(), request.limit_current());
-    p_controller_->process_can_packet();
+    p_controller_->process_packet();
   }
 }
 
@@ -163,7 +163,7 @@ void CybergearBridge::process_set_limit_torque(const ByteArray& request_packet)
   SetLimitTorqueRequestPacket request(request_packet);
   if (request.unpack()) {
     p_controller_->set_torque_limit(request.id(), request.limit_torque());
-    p_controller_->process_can_packet();
+    p_controller_->process_packet();
   }
 }
 
@@ -172,7 +172,7 @@ void CybergearBridge::process_set_position_control_gain(const ByteArray& request
   SetPositionControlGainRequestPacket request(request_packet);
   if (request.unpack()) {
     p_controller_->set_position_control_gain(request.id(), request.kp());
-    p_controller_->process_can_packet();
+    p_controller_->process_packet();
   }
 }
 
@@ -181,7 +181,7 @@ void CybergearBridge::process_set_velocity_control_gain(const ByteArray& request
   SetVelocityControlGainRequestPacket request(request_packet);
   if (request.unpack()) {
     p_controller_->set_velocity_control_gain(request.id(), request.kp(), request.ki());
-    p_controller_->process_can_packet();
+    p_controller_->process_packet();
   }
 }
 

--- a/src/cybergear_bridge_packet.hh
+++ b/src/cybergear_bridge_packet.hh
@@ -83,7 +83,6 @@ public:
     SetLimitTorque,       //!< set limit torque
     SetPositionControlGain, //!< set position control gain
     SetVelocityControlGain, //!< set velocity control gain
-    // SetCurrentParameter,
     _INVALID_TYPE_RANGE
   };
 

--- a/src/cybergear_can_interface.hh
+++ b/src/cybergear_can_interface.hh
@@ -1,0 +1,16 @@
+#ifndef CYBERGEAR_CAN_INTERFACE_HH
+#define CYBERGEAR_CAN_INTERFACE_HH
+
+#include <inttypes.h>
+
+class CybergearCanInterface
+{
+public:
+  CybergearCanInterface() {}
+  virtual ~CybergearCanInterface() {}
+  virtual bool send_message(uint32_t id, const uint8_t *data, uint8_t len, bool ext) = 0;
+  virtual bool read_message(unsigned long& id, uint8_t *data, uint8_t& len) = 0;
+  virtual bool available() = 0;
+};
+
+#endif // CYBERGEAR_CAN_INTERFACE_HH

--- a/src/cybergear_can_interface_esp32.cpp
+++ b/src/cybergear_can_interface_esp32.cpp
@@ -1,0 +1,91 @@
+#include "cybergear_can_interface_esp32.hh"
+#include "cybergear_can_interface.hh"
+#include "cybergear_driver_utils.hh"
+#include <M5Stack.h>
+#include <cstdint>
+#include <cstring>
+#include <RingBuf.h>
+
+// use arduino-CAN
+#include <CAN.h>
+
+struct CanMessage
+{
+  uint64_t tx_id;
+  uint64_t rx_id;
+  bool is_extended;
+  bool is_rtr;
+  uint8_t dlc;
+  uint8_t data[8];
+};
+static RingBuf<CanMessage, 100> buffer;
+
+static void on_receive(int size)
+{
+  CanMessage msg;
+  msg.is_extended = CAN.packetExtended();
+  msg.is_rtr = CAN.packetRtr();
+  msg.tx_id = CAN.packetTxId();
+  msg.rx_id = CAN.packetRxId();
+  msg.dlc = CAN.packetDlc();
+  for (uint8_t idx = 0; idx < msg.dlc; ++idx) {
+    if (CAN.available()) {
+      msg.data[idx] = CAN.read();
+    }
+  }
+  buffer.lockedPushOverwrite(msg);
+}
+
+CybergearCanInterfaceEsp32::CybergearCanInterfaceEsp32()
+  : CybergearCanInterface()
+{}
+
+CybergearCanInterfaceEsp32::~CybergearCanInterfaceEsp32()
+{}
+
+bool CybergearCanInterfaceEsp32::init(uint8_t rx_pin, uint8_t tx_pin)
+{
+  CAN.setPins(rx_pin,tx_pin);
+  CAN.onReceive(on_receive);
+  if (!CAN.begin(1000E3)) {
+    return false;
+  }
+
+  return true;
+}
+
+bool CybergearCanInterfaceEsp32::send_message(uint32_t id, const uint8_t *data, uint8_t len, bool ext)
+{
+  // change packet type
+  if (ext) {
+    CAN.beginExtendedPacket(id);
+  } else {
+    CAN.beginPacket(id);
+  }
+
+  // send packet
+  CAN.write(data, len);
+  CAN.endPacket();
+  return true;
+}
+
+bool CybergearCanInterfaceEsp32::read_message(unsigned long& id, uint8_t *data, uint8_t& len)
+{
+  // check empty
+  if (buffer.isEmpty()) return false;
+
+  // get mseesage from buffer
+  CanMessage msg;
+  if (!buffer.lockedPop(msg)) return false;
+
+  id = msg.rx_id;
+  len = msg.dlc;
+  memcpy(data, msg.data, len);
+  return true;
+}
+
+
+bool CybergearCanInterfaceEsp32::available()
+{
+  return (buffer.isEmpty() == false);
+}

--- a/src/cybergear_can_interface_esp32.hh
+++ b/src/cybergear_can_interface_esp32.hh
@@ -1,0 +1,30 @@
+#ifndef CYBERGEAR_CAN_INTERFACE_ESP32_HH
+#define CYBERGEAR_CAN_INTERFACE_ESP32_HH
+
+#include "cybergear_can_interface.hh"
+
+#define M5_CANBUS_TRANSIVER_UNIT
+#ifndef M5_CANBUS_TRANSIVER_UNIT
+#define M5_ESP32_DEFAULT_RX_PIN   22
+#define M5_ESP32_DEFAULT_TX_PIN   21
+#else
+#define M5_ESP32_DEFAULT_RX_PIN   5
+#define M5_ESP32_DEFAULT_TX_PIN   15
+#endif
+
+class CybergearCanInterfaceEsp32 : public CybergearCanInterface
+{
+public:
+  CybergearCanInterfaceEsp32();
+  virtual ~CybergearCanInterfaceEsp32();
+  bool init(uint8_t rx_pin = M5_ESP32_DEFAULT_RX_PIN, uint8_t tx_pin = M5_ESP32_DEFAULT_TX_PIN);
+  virtual bool send_message(uint32_t id, const uint8_t *data, uint8_t len, bool ext);
+  virtual bool read_message(unsigned long& id, uint8_t *data, uint8_t& len);
+  virtual bool available();
+
+private:
+  uint8_t receive_buffer_[64];  //!< receive buffer
+};
+
+#endif // ESP_CAN_INTERFACE_HH
+

--- a/src/cybergear_can_interface_mcp.cpp
+++ b/src/cybergear_can_interface_mcp.cpp
@@ -1,0 +1,56 @@
+#include "cybergear_can_interface_mcp.hh"
+#include "cybergear_driver_utils.hh"
+#include "mcp_can.h"
+
+
+CybergearCanInterfaceMcp::CybergearCanInterfaceMcp()
+  : pcan_(nullptr)
+{}
+
+CybergearCanInterfaceMcp::~CybergearCanInterfaceMcp()
+{}
+
+bool CybergearCanInterfaceMcp::init(uint8_t cs_pin, uint8_t int_pin)
+{
+  if (pcan_ != nullptr)
+  {
+    CG_DEBUG_PRINLN("Failed to open can intetrface. CAN interface has already opened.");
+    return false;
+  }
+
+  pcan_ = new MCP_CAN(cs_pin);
+  if (!pcan_->begin(MCP_ANY, CAN_1000KBPS, MCP_8MHZ) == CAN_OK)
+  {
+    CG_DEBUG_PRINLN("Failed to open can intetrface.");
+    return false;
+  }
+
+  pcan_->setMode(MCP_NORMAL);
+  pinMode(int_pin, INPUT);
+  return true;
+}
+
+bool CybergearCanInterfaceMcp::send_message(uint32_t id, const uint8_t *data, uint8_t len, bool ext)
+{
+  uint32_t msg_id = id;
+  uint8_t ret = pcan_->sendMsgBuf(msg_id, ext, len, const_cast<uint8_t *>(data));
+  return (ret == CAN_OK);
+}
+
+bool CybergearCanInterfaceMcp::read_message(unsigned long& id, uint8_t *data, uint8_t& len)
+{
+  if (pcan_->checkReceive() != CAN_MSGAVAIL) {
+    return false;
+  }
+
+  uint8_t ret = pcan_->readMsgBuf(&id, &len, data);
+  return (ret == CAN_OK);
+}
+
+bool CybergearCanInterfaceMcp::available()
+{
+  if (pcan_->checkReceive() != CAN_MSGAVAIL) {
+    return false;
+  }
+  return true;
+}

--- a/src/cybergear_can_interface_mcp.hh
+++ b/src/cybergear_can_interface_mcp.hh
@@ -1,0 +1,27 @@
+#ifndef CYBERGEAR_CAN_INTERFACE_MCP_HH
+#define CYBERGEAR_CAN_INTERFACE_MCP_HH
+
+#include "cybergear_can_interface.hh"
+#define M5_COMMU_BORAD_CS_PIN   12
+#define M5_COMMU_BORAD_INT_PIN  15
+
+// foward definition
+class MCP_CAN;
+
+class CybergearCanInterfaceMcp : public CybergearCanInterface
+{
+public:
+  CybergearCanInterfaceMcp();
+  virtual ~CybergearCanInterfaceMcp();
+  bool init(uint8_t cs_pin=M5_COMMU_BORAD_CS_PIN, uint8_t int_pin=M5_COMMU_BORAD_INT_PIN);
+  virtual bool send_message(uint32_t id, const uint8_t *data, uint8_t len, bool ext);
+  virtual bool read_message(unsigned long& id, uint8_t *data, uint8_t& len);
+  virtual bool available();
+
+private:
+  MCP_CAN *pcan_ = nullptr;
+  uint8_t receive_buffer_[64];  //!< receive buffer
+};
+
+#endif // CYBERGEAR_CAN_INTERFACE_MCP_HH
+

--- a/src/cybergear_controller.cpp
+++ b/src/cybergear_controller.cpp
@@ -2,7 +2,7 @@
 #include "cybergear_driver.hh"
 #include "cybergear_driver_defs.hh"
 #include <mcp_can.h>
-#include <M5Stack.h>
+#include <cmath>
 
 CybergearController::CybergearController(uint8_t master_can_id)
   : can_(NULL)
@@ -13,8 +13,24 @@ CybergearController::CybergearController(uint8_t master_can_id)
 CybergearController::~CybergearController()
 {}
 
-bool CybergearController::init(const std::vector<uint8_t> ids, uint8_t mode, MCP_CAN* can)
+bool CybergearController::init(const std::vector<uint8_t> & ids, uint8_t mode, MCP_CAN* can)
 {
+  std::vector<CybergearSoftwareConfig> configs;
+  for (uint8_t idx = 0; idx < ids.size(); ++idx) {
+    CybergearSoftwareConfig config;
+    config.id = ids[idx];
+    configs.push_back(config);
+  }
+
+  return init(ids, configs, mode, can);
+}
+
+bool CybergearController::init(const std::vector<uint8_t> & ids, const std::vector<CybergearSoftwareConfig> & sw_configs, uint8_t mode, MCP_CAN* can)
+{
+  if (ids.size() != sw_configs.size()) {
+    return false;
+  }
+
   // setup variables
   can_ = can;
   motor_ids_ = ids;       // for send sequence
@@ -29,19 +45,53 @@ bool CybergearController::init(const std::vector<uint8_t> ids, uint8_t mode, MCP
     motor_update_flag_[ids[idx]] = false;
   }
 
+  // copy sw configs
+  for (uint8_t idx = 0; idx < sw_configs.size(); ++idx) {
+    sw_configs_[sw_configs[idx].id] = sw_configs[idx];
+  }
+
   return true;
 }
 
-bool CybergearController::set_motor_config(const std::vector<CybergearConfig>& configs)
+bool CybergearController::set_run_mode(const std::vector<uint8_t> & ids, const std::vector<uint8_t> modes)
 {
+  if (ids.size() != modes.size()) return false;
   bool ret = true;
-  for (uint8_t idx = 0; idx < configs.size(); ++idx) {
-    ret &= set_motor_config(configs[idx]);
+  for (uint8_t idx = 0; idx < ids.size(); ++idx) {
+    ret &= set_run_mode(ids[idx], modes[idx]);
   }
   return ret;
 }
 
-bool CybergearController::set_motor_config(const CybergearConfig& config)
+bool CybergearController::set_run_mode(uint8_t mode)
+{
+  for (uint8_t idx = 0; idx < motor_ids_.size(); ++idx) {
+    drivers_[motor_ids_[idx]].set_run_mode(mode);
+  }
+  return true;
+}
+
+bool CybergearController::set_run_mode(uint8_t id, uint8_t mode)
+{
+  if (!check_motor_id(id)) return false;
+  drivers_[id].set_run_mode(mode);
+  return true;
+}
+
+bool CybergearController::set_motor_config(const std::vector<CybergearHardwareConfig>& configs)
+{
+  bool ret = true;
+  for (uint8_t idx = 0; idx < configs.size(); ++idx) {
+    if (set_motor_config(configs[idx])) {
+      hw_configs_[configs[idx].id] = configs[idx];
+    } else {
+      ret = false;
+    }
+  }
+  return ret;
+}
+
+bool CybergearController::set_motor_config(const CybergearHardwareConfig& config)
 {
   if (!check_motor_id(config.id)) return false;
 
@@ -110,7 +160,7 @@ bool CybergearController::enable_motor(uint8_t id, uint8_t mode)
 
 bool CybergearController::enable_motors()
 {
-  for (uint8_t idx; idx < motor_ids_.size(); ++idx) {
+  for (uint8_t idx = 0; idx < motor_ids_.size(); ++idx) {
     drivers_[motor_ids_[idx]].enable_motor();
   }
   return true;
@@ -125,7 +175,7 @@ bool CybergearController::reset_motor(uint8_t id)
 
 bool CybergearController::reset_motors()
 {
-  for (uint8_t idx; idx < motor_ids_.size(); ++idx) {
+  for (uint8_t idx = 0; idx < motor_ids_.size(); ++idx) {
     drivers_[motor_ids_[idx]].reset_motor();
   }
   return true;
@@ -148,16 +198,17 @@ bool CybergearController::send_motion_command(const std::vector<uint8_t> ids, co
 bool CybergearController::send_motion_command(uint8_t id, const CybergearMotionCommand& cmd)
 {
   if (!check_motor_id(id)) return false;
-  drivers_[id].motor_control(cmd.position, cmd.velocity, cmd.effort, cmd.kp, cmd.kd);
+  float pos = std::max(std::min(cmd.position, sw_configs_[id].upper_position_limit), sw_configs_[id].lower_position_limit);
+  float vel = std::max(std::min(sw_configs_[id].direction * cmd.velocity, sw_configs_[id].limit_speed), -sw_configs_[id].limit_speed);
+  float eff = std::max(std::min(sw_configs_[id].direction * cmd.effort, sw_configs_[id].limit_torque), -sw_configs_[id].limit_torque);
+  drivers_[id].motor_control(pos, vel, eff, cmd.kp, cmd.kd);
   return true;
 }
 
 bool CybergearController::send_position_command(const std::vector<uint8_t> ids, const std::vector<float> positions)
 {
   // check size
-  if (ids.size() != positions.size()) {
-    return false;
-  }
+  if (ids.size() != positions.size()) return false;
 
   bool ret = true;
   for (uint8_t idx = 0; idx < ids.size(); ++idx) {
@@ -169,16 +220,16 @@ bool CybergearController::send_position_command(const std::vector<uint8_t> ids, 
 bool CybergearController::send_position_command(uint8_t id, float position)
 {
   if (!check_motor_id(id)) return false;
-  drivers_[id].set_position_ref(position);
+  float pos = std::max(std::min(position, sw_configs_[id].upper_position_limit), sw_configs_[id].lower_position_limit);
+  float cmd_pos = (pos - sw_configs_[id].position_offset) * sw_configs_[id].direction;
+  drivers_[id].set_position_ref(cmd_pos);
   return true;
 }
 
 bool CybergearController::send_speed_command(const std::vector<uint8_t> ids, const std::vector<float> speeds)
 {
   // check size
-  if (ids.size() != speeds.size()) {
-    return false;
-  }
+  if (ids.size() != speeds.size()) return false;
 
   bool ret = true;
   for (uint8_t idx = 0; idx < ids.size(); ++idx) {
@@ -190,16 +241,15 @@ bool CybergearController::send_speed_command(const std::vector<uint8_t> ids, con
 bool CybergearController::send_speed_command(uint8_t id, float speed)
 {
   if (!check_motor_id(id)) return false;
-  drivers_[id].set_speed_ref(speed);
+  float vel = std::max(std::min(sw_configs_[id].direction * speed, sw_configs_[id].limit_speed), -sw_configs_[id].limit_speed);
+  drivers_[id].set_speed_ref(vel);
   return true;
 }
 
 bool CybergearController::send_current_command(const std::vector<uint8_t> ids, const std::vector<float> currents)
 {
   // check size
-  if (ids.size() != currents.size()) {
-    return false;
-  }
+  if (ids.size() != currents.size()) return false;
 
   bool ret = true;
   for (uint8_t idx = 0; idx < ids.size(); ++idx) {
@@ -211,7 +261,8 @@ bool CybergearController::send_current_command(const std::vector<uint8_t> ids, c
 bool CybergearController::send_current_command(uint8_t id, float current)
 {
   if (!check_motor_id(id)) return false;
-  drivers_[id].set_current_ref(current);
+  float cur = std::max(std::min(sw_configs_[id].direction * current, sw_configs_[id].limit_current), -sw_configs_[id].limit_current);
+  drivers_[id].set_current_ref(cur);
   return true;
 }
 
@@ -228,6 +279,7 @@ bool CybergearController::get_motor_status(std::vector<MotorStatus> & status)
   for (uint8_t idx = 0; idx < motor_ids_.size(); ++idx) {
     if (drivers_.find(motor_ids_[idx]) == drivers_.end()) return false;
     MotorStatus mot = drivers_[motor_ids_[idx]].get_motor_status();
+    get_motor_status(motor_ids_[idx], mot);
     status.push_back(mot);
   }
   return true;
@@ -237,6 +289,16 @@ bool CybergearController::get_motor_status(uint8_t id, MotorStatus& status)
 {
   if (!check_motor_id(id)) return false;
   status = drivers_[id].get_motor_status();
+  status.position = sw_configs_[id].direction * status.position + sw_configs_[id].position_offset;
+  status.velocity *= sw_configs_[id].direction;
+  status.effort *= sw_configs_[id].direction;
+  return true;
+}
+
+bool CybergearController::get_software_config(uint8_t id, CybergearSoftwareConfig& config)
+{
+  if (!check_motor_id(id)) return false;
+  config = sw_configs_[id];
   return true;
 }
 
@@ -294,10 +356,14 @@ std::vector<uint8_t> CybergearController::motor_ids() const
 
 bool CybergearController::check_motor_id(uint8_t id)
 {
-  CybergearDriverMap::iterator it = drivers_.find(id);
-  if (it == drivers_.end()) {
+  if (drivers_.find(id) == drivers_.end()) {
     return false;
   }
+
+  if (sw_configs_.find(id) == sw_configs_.end()) {
+    return false;
+  }
+
   return true;
 }
 

--- a/src/cybergear_controller.hh
+++ b/src/cybergear_controller.hh
@@ -1,12 +1,11 @@
 #ifndef CYBER_GEAR_CONTROLLER_HH
 #define CYBER_GEAR_CONTROLLER_HH
 
+#include "cybergear_can_interface.hh"
 #include "cybergear_driver.hh"
-
 #include <cstdint>
 #include <sys/types.h>
 #include <unordered_map>
-#include <mcp_can.h>
 #include <vector>
 #include <cmath>
 
@@ -114,7 +113,7 @@ public:
    * @return true   succeeded to init this class
    * @return false  failed to init this class
    */
-  bool init(const std::vector<uint8_t> & ids, uint8_t mode, MCP_CAN* can);
+  bool init(const std::vector<uint8_t> & ids, uint8_t mode, CybergearCanInterface* can);
 
   /**
    * @brief Init cybergear controller class
@@ -126,7 +125,7 @@ public:
    * @return true         succeeded to init this class
    * @return false        failed to init this class
    */
-  bool init(const std::vector<uint8_t> & ids, const std::vector<CybergearSoftwareConfig> & sw_configs, uint8_t mode, MCP_CAN* can);
+  bool init(const std::vector<uint8_t> & ids, const std::vector<CybergearSoftwareConfig> & sw_configs, uint8_t mode, CybergearCanInterface* can);
 
   /**
    * @brief Set the run mode
@@ -341,7 +340,7 @@ public:
    * @return true   success to update data
    * @return false  failed to update data
    */
-  bool process_can_packet();
+  bool process_packet();
 
   bool check_update_flag(uint8_t id);
   bool reset_update_flag(uint8_t id);
@@ -364,7 +363,7 @@ private:
   CybergearSoftwareConfigMap sw_configs_;
   uint8_t control_mode_;
 
-  MCP_CAN *can_;
+  CybergearCanInterface *can_;
   uint8_t master_can_id_;
   uint8_t receive_buffer_[64];
   unsigned long recv_count_;

--- a/src/cybergear_driver.hh
+++ b/src/cybergear_driver.hh
@@ -2,14 +2,14 @@
 #define CYBER_GEAR_DRIVER_H
 
 #include "cybergear_driver_defs.hh"
-#include "mcp_can.h"
-
+#include "cybergear_can_interface.hh"
 
 /**
  * @brief MotorStatus class
  */
 struct MotorStatus
 {
+  unsigned long stamp_usec;     //< timestamp
   uint8_t motor_id;             //!< motor id
   float position;               //!< encoder position (-4pi to 4pi)
   float velocity;               //!< motor velocity (-30rad/s to 30rad/s)
@@ -46,9 +46,9 @@ public:
   /**
    * @brief Init this class
    *
-   * @param MCP_CAN mcp_can object for can communication
+   * @param ican CybergearCanInterface object for communication
    */
-  void init(MCP_CAN *can);
+  void init(CybergearCanInterface *ican);
 
   /**
    * @brief Init motor
@@ -195,7 +195,7 @@ public:
    * @return true   motor status updated
    * @return false  motor status not updated
    */
-  bool process_can_packet();
+  bool process_packet();
 
   /**
    * @brief Update motor status from buffer
@@ -265,7 +265,7 @@ private:
   void print_can_packet(uint32_t id, uint8_t *data, uint8_t len);
 
 
-  MCP_CAN* can_;                //!< can connection instance
+  CybergearCanInterface *can_;  //!< can connection instance
   uint8_t master_can_id_;       //!< master can id
   uint8_t target_can_id_;       //!< target can id
   uint8_t run_mode_;            //!< run mode

--- a/src/cybergear_driver_defs.hh
+++ b/src/cybergear_driver_defs.hh
@@ -60,5 +60,7 @@
 #define RET_CYBERGEAR_INVALID_CAN_ID  0x02
 #define RET_CYBERGEAR_INVALID_PACKET  0x03
 
+#define CW      1
+#define CCW     -1
 
 #endif // !CYBER_GEAR_DRIVER_DEFS_H

--- a/src/cybergear_driver_utils.hh
+++ b/src/cybergear_driver_utils.hh
@@ -1,0 +1,16 @@
+#ifndef CYBERGEAR_DRIVER_UTILS_HH
+#define CYBERGEAR_DRIVER_UTILS_HH
+
+// #define CG_DEBUG
+#ifndef CG_DEBUG
+#define CG_DEBUG_FUNC()
+#define CG_DEBUG_PRINTF(fmt, ...)
+#define CG_DEBUG_PRINLN(msg)
+#else
+#include <M5Stack.h>
+#define CG_DEBUG_FUNC Serial.printf("l%d %s\n", __LINE__, __func__);
+#define CG_DEBUG_PRINTF(fmt, ...) Serial.printf(fmt, __VA_ARGS__);
+#define CG_DEBUG_PRINLN(msg) Serial.println(msg);
+#endif
+
+#endif // CYBERGEAR_DRIVER_UTILS_HH


### PR DESCRIPTION
I have added code to utilize the CAN interface of the ESP32. By using this code, we can improve the control frequency of Cybergear compared to when using the MCP2515 of the CommuModule. The modules that have been tested are listed below.

* [LAN Module W5500 with PoE V12](https://shop.m5stack.com/products/lan-module-w5500-with-poe-v12)
* [CANBus Unit(CA-IS3050G)](https://shop.m5stack.com/products/canbus-unitca-is3050g)